### PR TITLE
Added limit parameter to Kline query request.

### DIFF
--- a/binance/market.go
+++ b/binance/market.go
@@ -49,7 +49,7 @@ func (b *Binance) GetKlines(q KlineQuery) (klines []Kline, err error) {
         return
     }
 
-    reqUrl := fmt.Sprintf("api/v1/klines?symbol=%s&interval=%s", q.Symbol, q.Interval)
+    reqUrl := fmt.Sprintf("api/v1/klines?symbol=%s&interval=%s&limit=%d", q.Symbol, q.Interval, q.Limit)
 
     _, err = b.client.do("GET", reqUrl, "", false, &klines)
     if err != nil {

--- a/binance/market_request.go
+++ b/binance/market_request.go
@@ -47,6 +47,7 @@ func (q *SymbolQuery) ValidateSymbolQuery() error {
 type KlineQuery struct {
     Symbol    string
     Interval  string
+    Limit     int64
 }
 
 func (q *KlineQuery) ValidateKlineQuery() error {
@@ -55,6 +56,9 @@ func (q *KlineQuery) ValidateKlineQuery() error {
             return errors.New("KlineQuery requires a symbol")
         case !IntervalEnum[q.Interval]:
             return errors.New("Invalid Kline Interval")
+        case q.Limit == 0:
+            q.Limit = 500
+            return nil
         default:
             return nil
     }


### PR DESCRIPTION
As per API docs, it is possible to send 'limit' parameter to Kline/candlesticks endpoint. Current default is 500; however, it can be sometimes useful to get less than that via API.