### PR TITLE
Added ping for Rest and Withdrawal API. Changed API base URL.

### DIFF
--- a/binance/binance.go
+++ b/binance/binance.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-    BaseUrl = "https://www.binance.com"
+    BaseUrl = "https://api.binance.com"
 )
 
 type Binance struct {

--- a/binance/market.go
+++ b/binance/market.go
@@ -128,3 +128,17 @@ func (b *Binance) GetExchangeInfo() (exchangeinfo ExchangeInfo, err error) {
 
     return
 }
+
+// Ping Rest API. If no error is returned, API is up and running.
+func (b *Binance) Ping() (pingResponse PingResponse, err error) {
+	_, err = b.client.do("GET", "api/v1/ping", "", false, &pingResponse)
+
+	return
+}
+
+// Ping Withdrawal API. Status is returned in response.
+func (b *Binance) GetWithdrawalSystemStatus() (withdrawalSystemStatus WithdrawalSystemStatus, err error) {
+	_, err = b.client.do("GET", "wapi/v3/systemStatus.html", "", false, &withdrawalSystemStatus)
+
+	return
+}

--- a/binance/market_response.go
+++ b/binance/market_response.go
@@ -153,6 +153,19 @@ type RateLimit struct {
     RateLimitType string `json:"rateLimitType"`
 }
 
+type PingResponse struct{}
+
+type WithdrawalSystemStatus struct {
+	Status SystemStatus `json:"status"`
+	Msg    string       `json:"msg"`
+}
+
+type SystemStatus int64
+
+const (
+	SystemStatusNormal      SystemStatus = 0
+	SystemStatusMaintenance SystemStatus = 1
+)
 
 // Custom Unmarshal function to handle response data format
 func (k *Kline) UnmarshalJSON(b []byte) error {

--- a/binance/tests/ping_test.go
+++ b/binance/tests/ping_test.go
@@ -1,0 +1,17 @@
+package ping_test
+
+import (
+	"github.com/pdepip/go-binance/binance"
+	"testing"
+)
+
+func TestPing(t *testing.T) {
+	client := binance.New("", "")
+
+	if ping, err := client.Ping(); err != nil {
+		t.Fatal(err)
+	} else {
+		t.Logf("%+v\n", ping)
+	}
+
+}

--- a/binance/tests/withdrawal_system_status_test.go
+++ b/binance/tests/withdrawal_system_status_test.go
@@ -1,0 +1,23 @@
+package withdrawal_system_status_test
+
+import (
+	"github.com/pdepip/go-binance/binance"
+	"testing"
+)
+
+func TestWithdrawalSystemStatus(t *testing.T) {
+	client := binance.New("", "")
+
+	if status, err := client.GetWithdrawalSystemStatus(); err != nil {
+		t.Fatal(err)
+	} else {
+		switch {
+		case status.Status == binance.SystemStatusNormal:
+			t.Logf("Status normal - full response: %+v", status)
+		case status.Status == binance.SystemStatusMaintenance:
+			t.Logf("Status maintenance - full response: %+v", status)
+		default:
+			t.Errorf("Unexpected status: %+v", status)
+		}
+	}
+}


### PR DESCRIPTION
Binance had a downtime between 07 and 09.02.2018, which led them to introduce new Endpoint for checking Withdrawal API status. 
Also, they changed their base URL from `www.binance.com` to `api.binance.com`. 
Full info can be found at: https://github.com/binance-exchange/binance-official-api-docs