### PR TITLE
Fix "lastUpdateId" field name in OrderBook reply

### DIFF
--- a/binance/market_response.go
+++ b/binance/market_response.go
@@ -14,7 +14,7 @@ import (
 
 // Result from: GET /api/v1/depth
 type OrderBook struct {
-	LastUpdatedId int64   `json:"lastUpdatedId"`
+	LastUpdateId  int64   `json:"lastUpdateId"`
 	Bids          []Order `json:"bids"`
 	Asks          []Order `json:"asks"`
 }


### PR DESCRIPTION
The fieldname had a typo and was thus always 0.