### PR TITLE
Fix compile, origClientOrderId is not yet supported in query

### DIFF
--- a/binance/account.go
+++ b/binance/account.go
@@ -109,7 +109,7 @@ func (b *Binance) CheckOrder(query OrderQuery) (status OrderStatus, err error) {
 		return
 	}
 
-	reqUrl := fmt.Sprintf("api/v3/order?symbol=%s&orderId=%d&origClientOrderId=%s&recvWindow=%d", query.Symbol, query.OrderId, query.RecvWindow)
+	reqUrl := fmt.Sprintf("api/v3/order?symbol=%s&orderId=%d&recvWindow=%d", query.Symbol, query.OrderId, query.RecvWindow)
 
 	_, err = b.client.do("GET", reqUrl, "", true, &status)
 	if err != nil {


### PR DESCRIPTION
Sprintf complained that `%s` didn't fit `query.RecvWindow`