### PR TITLE
3 args being passed to Sprintf, but 4 args needed.

### DIFF
--- a/binance/account.go
+++ b/binance/account.go
@@ -109,7 +109,11 @@ func (b *Binance) CheckOrder(query OrderQuery) (status OrderStatus, err error) {
 		return
 	}
 
-	reqUrl := fmt.Sprintf("api/v3/order?symbol=%s&orderId=%d&origClientOrderId=%s&recvWindow=%d", query.Symbol, query.OrderId, query.RecvWindow)
+	reqUrl := fmt.Sprintf("api/v3/order?symbol=%v&orderId=%v&origClientOrderId=%v&recvWindow=%v",
+		query.Symbol,
+		query.OrderId,
+		query.OrderId,
+		query.RecvWindow)
 
 	_, err = b.client.do("GET", reqUrl, "", true, &status)
 	if err != nil {


### PR DESCRIPTION
In recent version of Go the mismatch in arguments is a compiler error.

I noticed this on Go 1.10.3