### PR TITLE
Allow users to set http.Client

### DIFF
--- a/binance/binance.go
+++ b/binance/binance.go
@@ -11,6 +11,10 @@
 */
 package binance
 
+import (
+	"net/http"
+)
+
 //"errors"
 
 const (
@@ -34,4 +38,13 @@ func handleErr(r jsonResponse) error {
 func New(key, secret string) *Binance {
 	client := NewClient(key, secret)
 	return &Binance{client}
+}
+
+// Override the http.Client to use for network connections
+//
+// This is used for setting timeouts and other network settings and
+// can also be useful for sharing connections when using multiple Binance
+// instances.
+func (b *Binance) SetHttpClient(client *http.Client) {
+	b.client.httpClient = client
 }


### PR DESCRIPTION
This is used for setting timeouts and other network settings and
can also be useful for sharing connections when using multiple Binance
instances.